### PR TITLE
Fixing images in markdown

### DIFF
--- a/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
+++ b/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
@@ -59,7 +59,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 2. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: importar el repositorio de Git de eShopOnWeb
 
@@ -67,7 +67,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar un repositorio**. Seleccione **Import** (Importar). En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.

--- a/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
@@ -47,7 +47,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 2. Haz clic en **Avanzado** y especifica **Scrum** como el **Proceso de elemento de trabajo**.
  Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 ### Ejercicio 1: administración de un proyecto con la metodología ágil
 
@@ -65,15 +65,15 @@ Cada proyecto nuevo se configura con un equipo predeterminado, que coincide con 
 
 2. Haz clic en el icono de engranaje con la etiqueta **Configuración del proyecto** situada en la esquina inferior izquierda de la página para abrir la página **Configuración del proyecto**.
 
-    ![Ventana de proyecto de Azure DevOps. Haz clic en la opción "Configuración del proyecto".](images/m1/project_settings_v1.png)
+    ![Ventana de proyecto de Azure DevOps. Haz clic en la opción "Configuración del proyecto".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/project_settings_v1.png)
 
 3. En la sección **General**, selecciona la pestaña **Teams**. Ya hay un equipo predeterminado en este proyecto, **EShopOnWeb Team**, pero crearás uno nuevo para este laboratorio. Haz clic en **Nuevo equipo**.
 
-    ![En la ventana de configuración del proyecto, pestaña "Equipos", haz clic en "Nuevo equipo".](images/m1/new_team_v1.png)
+    ![En la ventana de configuración del proyecto, pestaña "Equipos", haz clic en "Nuevo equipo".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/new_team_v1.png)
 
 4. En el panel **Crear un nuevo equipo**, en el cuadro de texto **Nombre del equipo**, escribe **EShop-Web**, deja otras opciones con sus valores predeterminados y haz clic en **Crear**.
 
-    ![En la ventana "Crear un nuevo equipo", asigna el nombre de equipo "EShop-Web" y haz clic en "Crear".](images/m1/eshopweb-team_v1.png)
+    ![En la ventana "Crear un nuevo equipo", asigna el nombre de equipo "EShop-Web" y haz clic en "Crear".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/eshopweb-team_v1.png)
 
 5. En la lista de **Equipos**, selecciona el equipo recién creado para ver sus detalles.
 
@@ -81,30 +81,30 @@ Cada proyecto nuevo se configura con un equipo predeterminado, que coincide con 
 
 6. Haz clic en el vínculo **Iteraciones y rutas de área** en la parte superior de la página **EShop-Web** para empezar a definir la programación y el ámbito del equipo.
 
-    ![En la ventana de configuración del proyecto, pestaña "Equipos", equipo "EShop-WEB", haz clic en "Iteraciones y rutas de área".](images/m1/EShop-WEB-iterationsareas_v1.png)
+    ![En la ventana de configuración del proyecto, pestaña "Equipos", equipo "EShop-WEB", haz clic en "Iteraciones y rutas de área".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-iterationsareas_v1.png)
 
 7. En la parte superior del panel **Paneles**, selecciona la pestaña **Iteraciones** y haz clic en **+ Seleccionar iteraciones.**
 
-    ![En la pestaña "iteraciones", haz clic en "Seleccionar iteración".](images/m1/EShop-WEB-select_iteration_v1.png)
+    ![En la pestaña "iteraciones", haz clic en "Seleccionar iteración".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-select_iteration_v1.png)
 
 8. Selecciona **EShopOnWeb\Sprint 1** y haz clic en **Guardar y cerrar**. Ten en cuenta que este primer sprint aparecerá en la lista de iteraciones, pero las fechas aún no están establecidas.
 9. Selecciona **Sprint 1** y haz clic en los **puntos suspensivos (...)**. En el menú contextual, selecciona **Editar**.
 
-     ![En la pestaña "iteraciones", haz clic en "Editar".](images/m1/EShop-WEB-edit_iteration_v1.png)
+     ![En la pestaña "iteraciones", haz clic en "Editar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-edit_iteration_v1.png)
 
     > **Nota**: especifica la fecha de inicio como el primer día laborable de la semana pasada y cuenta 3 semanas de trabajo completas para cada sprint. Por ejemplo, si el 6 de marzo es el primer día laborable del sprint, el periodo dura hasta el 24 de marzo. El sprint 2 comienza el 27 de marzo, que es tres semanas después del 6 de marzo.
 
 10. Repite el paso anterior para agregar el **Sprint 2** y el **Sprint 3**. Podrías decir que estamos en la segunda semana del primer sprint.
 
-    ![Haz lo mismo para los Sprints 2 y 3, y asegúrate de que se creen para el equipo "EShop-Web".](images/m1/EShop-WEB-3sprints_v1.png)
+    ![Haz lo mismo para los Sprints 2 y 3, y asegúrate de que se creen para el equipo "EShop-Web".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-3sprints_v1.png)
 
 11. Todavía en el panel **Configuración del proyecto / Boards / Configuración del equipo**, en la parte superior del panel, seleccione la pestaña **Áreas**. Encontrará un área generada automáticamente con el nombre que coincida con el nombre del equipo.
 
-![En Áreas, seleccione EShopOnWeb\EShop-Web](images/m1/EShop-WEB-areas_v1.png)
+![En Áreas, seleccione EShopOnWeb\EShop-Web](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-areas_v1.png)
 
 12. Haz clic en los puntos suspensivos (...) junto a la entrada **área predeterminada** y, en la lista desplegable, selecciona **Incluir subáreas**.
 
-    ![En la pestaña "Áreas", haz clic en el icono de puntos suspensivos (...) del área "EShop-WEB" y selecciona "Incluir subáreas".](images/m1/EShop-WEB-sub_areas_v1.png)
+    ![En la pestaña "Áreas", haz clic en el icono de puntos suspensivos (...) del área "EShop-WEB" y selecciona "Incluir subáreas".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-sub_areas_v1.png)
 
     > **Nota**: la configuración predeterminada para todos los equipos excluye las rutas de subárea. Lo cambiaremos para incluir subáreas para que el equipo pueda ver todos los elementos de trabajo de todos los equipos. O bien, el equipo de administración también puede optar por no incluir subáreas, lo que oculta automáticamente los elementos de trabajo en cuanto se les asigna a uno de los equipos.
 
@@ -122,7 +122,7 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 
 2. En la ventana **Elementos de trabajo**, haz clic en **+ Nuevo elemento de trabajo > Epopeya**.
 
-    ![En la ventana "Paneles">"Elementos de trabajo", haz clic en "Nuevo elemento de trabajo" >Epopeya.](images/m1/EShop-WEB-create_epic_v1.png)
+    ![En la ventana "Paneles">"Elementos de trabajo", haz clic en "Nuevo elemento de trabajo" >Epopeya.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-create_epic_v1.png)
 
 3. En el cuadro de texto **Escribir título**, escribe **Entrenamiento sobre el producto**.
 4. En la esquina superior izquierda, selecciona la entrada **Sin asignar** y, en la lista desplegable, selecciona tu cuenta de usuario para asignar el nuevo elemento de trabajo.
@@ -130,7 +130,7 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 6. Junto a la entrada **Iteración**, selecciona la entrada **eShopOnWeb** y, en la lista desplegable, selecciona **Sprint 2**. Esto establecerá la **iteración** como **eShopOnWeb\Sprint 2**.
 7. Para terminar de hacer cambios, haz clic en **Guardar**. **No cierres**.
 
-    ![Escribe la información mostrada anteriormente y haz clic en "Guardar" en la ventana Epopeya.](images/m1/EShop-WEB-epic_details_v1.png)
+    ![Escribe la información mostrada anteriormente y haz clic en "Guardar" en la ventana Epopeya.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-epic_details_v1.png)
 
     > **Nota**: normalmente, uno completa con la mayor cantidad de información posible, pero esto es suficiente para este laboratorio.
 
@@ -139,18 +139,18 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 8. En la sección **Trabajo relacionado** en la parte inferior derecha, selecciona la entrada **Agregar vínculo** y, en la lista desplegable, selecciona **Nuevo elemento**.
 9. En el panel **Agregar vínculo**, en la lista desplegable **Tipo de vínculo**, selecciona **Secundario**. A continuación, en la lista desplegable **Tipo de elemento de trabajo**, selecciona **Característica**; en el cuadro de texto **Título** , escribe **Panel de entrenamiento** y haz clic en **Aceptar**.
 
-    ![Introduce el título "Panel de entrenamiento" y haz clic en "Aceptar".](images/m1/EShop-WEB-create_child_feature.png)
+    ![Introduce el título "Panel de entrenamiento" y haz clic en "Aceptar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-create_child_feature.png)
 
     > **Nota**: en el **panel de entrenamiento**, ten en cuenta que la asignación, el **área** y la **iteración** ya están establecidos en los mismos valores de la epopeya en la que se basa la característica. Asimismo, la característica se vincula automáticamente con el elemento primario desde el cual se creó.
 
 10. Haga clic en **Agregar vínculo** para guardar el elemento secundario. En el **Panel de formación** (Nueva característica), haga clic en **Guardar y cerrar**.
 
-![Epopeya con elemento secundario vinculado](images/m1/EShop-WEB-epic_with_linked_item_v1.png)
+![Epopeya con elemento secundario vinculado](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-epic_with_linked_item_v1.png)
 
 11. En el panel de navegación vertical del portal de Azure DevOps, en la lista de elementos **Paneles**, selecciona **Paneles**.
 12. En el panel **Paneles**, selecciona la entrada **paneles de EShop-WEB**. Se abrirá el panel para ese equipo determinado.
 
-    ![ En la ventana "Paneles>Paneles", selecciona "Paneles de EShop-WEB"](images/m1/EShop-WEB-_boards_v1.png)
+    ![ En la ventana "Paneles>Paneles", selecciona "Paneles de EShop-WEB"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-_boards_v1.png)
 
 13. En el panel **Paneles**, en la esquina superior derecha, selecciona la entrada **Elementos de trabajos pendientes** y, en la lista desplegable, selecciona **Características**.
 
@@ -159,7 +159,7 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 14. Mantén el puntero del mouse sobre el rectángulo que representa la característica **Panel de entrenamiento**. Aparecerán los puntos suspensivos (...) en la esquina superior derecha.
 15. Haz clic en el icono de puntos suspensivos (...) y, en la lista desplegable, selecciona **Agregar elemento de trabajo pendiente**.
 
-    ![Haz clic en los puntos suspensivos de la característica "Panel de entrenamiento" y haz clic en "Agregar elemento de trabajo pendiente".](images/m1/EShop-WEB-add_pb_v1.png)
+    ![Haz clic en los puntos suspensivos de la característica "Panel de entrenamiento" y haz clic en "Agregar elemento de trabajo pendiente".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-add_pb_v1.png)
 
 16. En el cuadro de texto del nuevo elemento de trabajo pendiente, escribe **Como cliente, me gustaría ver nuevos tutoriales** y presiona la tecla **Entrar** para guardar la entrada.
 
@@ -167,17 +167,17 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 
 17. Repite el paso anterior para agregar dos PBI más, diseñados para que el cliente vea los últimos tutoriales vistos y solicite nuevos tutoriales denominados, respectivamente, **Como cliente, me gustaría ver los últimos tutoriales que he visto** y **Como cliente, me gustaría solicitar nuevos tutoriales**.
 
-    ![Repite haciendo clic en "Agregar trabajo pendiente del producto" ](images/m1/EShop-WEB-pbis_v1.png)
+    ![Repite haciendo clic en "Agregar trabajo pendiente del producto" ](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-pbis_v1.png)
 
 18. En el panel **Paneles**, en la esquina superior derecha, selecciona la entrada **Características** y, en la lista desplegable, selecciona **Elementos de trabajo pendiente**.
 
-     !["Ver elementos de trabajo pendiente" ](images/m1/EShop-WEB-backlog_v1.png)
+     !["Ver elementos de trabajo pendiente" ](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-backlog_v1.png)
 
     > **Nota**: los elementos de trabajo pendiente tienen un estado que define en qué etapa del proceso se encuentran. Aunque puedes abrir y editar el elemento de trabajo con el formulario, es más fácil arrastrar las tarjetas hacia el panel.
 
 19. En la pestaña **Panel** del panel **EShop-WEB**, arrastra el primer elemento de trabajo denominado **Como cliente, me gustaría ver nuevos tutoriales** de las fases **Nuevo** a **Aprobado**.
 
-    ![Mueve el WIT del estado "Nuevo" a "Aprobado"](images/m1/EShop-WEB-new2ap_v1.png)
+    ![Mueve el WIT del estado "Nuevo" a "Aprobado"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-new2ap_v1.png)
 
     > **Nota**: también puedes expandir tarjetas de elementos de trabajo para obtener detalles editables de manera práctica.
 
@@ -186,13 +186,13 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 22. En la pestaña **Panel** del panel **EShop-WEB**, arrastra el segundo elemento de trabajo denominado **Como cliente, me gustaría ver los últimos tutoriales que he visto** desde la fase **Nuevo** hasta **Confirmado**.
 23. En la pestaña **Panel** del panel **EShop-WEB**, arrastra el tercer elemento de trabajo denominado **Como cliente, me gustaría solicitar nuevos tutoriales** de la fase **Nuevo** hasta **Listo**.
 
-    ![WIT movidos a columnas determinadas en los pasos anteriores](images/m1/EShop-WEB-board_pbis_v1.png)
+    ![WIT movidos a columnas determinadas en los pasos anteriores](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-board_pbis_v1.png)
 
     > **Nota**: el panel de tareas es una vista en los trabajos pendientes. También puedes usar la vista tabular.
 
 24. En la pestaña **Panel** del panel **EShop-WEB**, en la parte superior del panel, haz clic en **Ver como trabajo pendiente** para mostrar el formulario tabular.
 
-    ![En el panel "EShop-WEB", haz clic en "Ver como trabajo pendiente"](images/m1/EShop-WEB-view_backlog_v1.png)
+    ![En el panel "EShop-WEB", haz clic en "Ver como trabajo pendiente"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-view_backlog_v1.png)
 
     > **Nota**: puedes usar el signo más situado justo debajo de la etiqueta de pestaña **Trabajo pendiente** del panel **EShop-WEB** para ver las tareas anidadas en estos elementos de trabajo.
 
@@ -200,14 +200,14 @@ Los elementos de trabajo cumplen un rol destacado en Azure DevOps. Ya sea que se
 
 25. En la pestaña **Trabajo pendiente** del panel **EShop-WEB**, en la esquina superior izquierda del panel, haz clic en el segundo signo más de la parte superior, situado junto al primer elemento de trabajo. Aparecerá el panel **NUEVA TAREA**.
 
-    ![Haz clic en "+" para crear la tarea.](images/m1/new_task_v1.png)
+    ![Haz clic en "+" para crear la tarea.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/new_task_v1.png)
 
 26. En la parte superior del panel **NUEVA TAREA**, en el cuadro de texto **Escribir título**, escribe **Agregar página para los tutoriales más recientes**.
 27. En el panel **NUEVA TAREA**, en el cuadro de texto **Trabajo restante**, escribe **5**.
 28. En el panel **NUEVA TAREA**, en la lista desplegable **Actividad**, selecciona **Desarrollo**.
 29. En el panel **NUEVA TAREA**, haz clic en **Guardar y cerrar**.
 
-    ![Rellena los campos "Nueva tarea" y haz clic en "Guardar y cerrar".](images/m1/EShop-WEB-save_task_v1.png)
+    ![Rellena los campos "Nueva tarea" y haz clic en "Guardar y cerrar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-save_task_v1.png)
 
 30. Repite los cinco últimos pasos para agregar otra tarea denominada **Optimizar consulta de datos para los tutoriales más recientes **. Configura tu **Trabajo restante** con el valor **3** y elige la **Actividad**: **Diseño**. Haz clic en **Guardar y cerrar** cuando termines.
 
@@ -224,7 +224,7 @@ El trabajo pendiente de sprint debe contener toda la información que el equipo 
 1. En el panel de navegación vertical del portal de Azure DevOps, selecciona el icono **Paneles** y, en la lista de elementos **Paneles**, selecciona **Sprints**.
 2. En la pestaña **Panel de tareas** de la vista **Sprints**, en la barra de herramientas a la derecha, selecciona el símbolo ** Ver opciones** (directamente a la izquierda del icono de embudo) y, en la lista desplegable **Ver opciones**, selecciona la entrada **Detalles del trabajo**. Seleccione **Sprint 2** como filtro.
 
-    ![En la ventana "Paneles">"Sprints", el equipo "EShop-WEB", selecciona el icono "Ver opciones" y haz clic en "Detalles del trabajo".](images/m1/EShop-WEB-work_details_v1.png)
+    ![En la ventana "Paneles">"Sprints", el equipo "EShop-WEB", selecciona el icono "Ver opciones" y haz clic en "Detalles del trabajo".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-work_details_v1.png)
 
     > **Nota**: el sprint actual tiene un ámbito bastante limitado. Hay dos tareas en la fase **Tareas pendientes**. En este momento, no se ha asignado ninguna tarea. Ambas muestran un valor numérico a la derecha de la entrada **Sin asignar** que representa el cálculo del trabajo restante.
 
@@ -232,7 +232,7 @@ El trabajo pendiente de sprint debe contener toda la información que el equipo 
 
 4. Selecciona la pestaña **Capacidad** de la vista **Sprints**.
 
-![Vista de capacidad de sprint](images/m1/EShop-WEB-capacity_v1.png)
+![Vista de capacidad de sprint](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-capacity_v1.png)
 
     > **Note**: This view enables you to define what activities a user can take on and at what level of capacity.
 
@@ -240,19 +240,19 @@ El trabajo pendiente de sprint debe contener toda la información que el equipo 
 
     > **Nota**: esto representa 1 hora de trabajo de desarrollo al día. Ten en cuenta que puedes agregar actividades adicionales por usuario en caso de que hagan otras tareas además de desarrollo.
 
-![Establecer capacidad de desarrollo para un usuario](images/m1/EShop-WEB-capacity-setdevelopment_v1.png)
+![Establecer capacidad de desarrollo para un usuario](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-capacity-setdevelopment_v1.png)
 
     > **Note**: Let's assume you're also going to take some vacation. Which should be added to the capacity view too.
 
 6. En la pestaña ** Capacidad** de la vista **Sprints**, situada junto a la entrada que representa la cuenta de usuario, en la columna **Días libres**, haz clic en la entrada **0 días**. Aparecerá un panel en el que podrás establecer tus días libres.
 7. En el panel que se visualiza, usa la vista de calendario para establecer tus vacaciones de modo que abarquen cinco días laborables durante el sprint actual (dentro de las próximas tres semanas) y, cuando termines, haz clic en **Aceptar**.
 
-    ![Introduce "Inicio", "Finalización" y "Días libres" tal como se ha descrito.](images/m1/EShop-WEB-days_off_v1.png)
+    ![Introduce "Inicio", "Finalización" y "Días libres" tal como se ha descrito.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-days_off_v1.png)
 
 8. Cuando vuelvas a la pestaña **Capacidad** de la vista **Sprints**, haz clic en **Guardar**.
 9. Selecciona la pestaña **Panel de tareas** de la vista **Sprints**.
 
-    ![Revisa la información de la sección "Detalles del trabajo" y corrobora que todas las barras de control de tiempo sean verdes. ](images/m1/EShop-WEB-work_details_window_v1.png)
+    ![Revisa la información de la sección "Detalles del trabajo" y corrobora que todas las barras de control de tiempo sean verdes. ](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-work_details_window_v1.png)
 
     > **Nota:** ten en cuenta que el panel **Detalles del trabajo** se ha actualizado para reflejar el ancho de banda disponible. El número real que se muestra en el panel **Detalles del trabajo** puede variar, pero la capacidad total del sprint será igual que la cantidad de días laborables restantes hasta el final del sprint, ya que asignó 1 hora al día. Toma nota de este valor, ya que lo usarás en los próximos pasos.
 
@@ -260,7 +260,7 @@ El trabajo pendiente de sprint debe contener toda la información que el equipo 
 
 10. En la pestaña **Panel de tareas** de la vista **Sprints**, en el cuadro que representa **Agregar página para los tutoriales más recientes**, establece la cantidad prevista de horas en **14**, para que coincida con la capacidad total de este sprint, que has identificado en el paso anterior.
 
-    ![Revisa la información de la sección "Detalles del trabajo", que el tiempo asignado del equipo sea mayor que la capacidad.](images/m1/EShop-WEB-over_capacity_v1.png)
+    ![Revisa la información de la sección "Detalles del trabajo", que el tiempo asignado del equipo sea mayor que la capacidad.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-over_capacity_v1.png)
 
     > **Nota**: esto amplía automáticamente el **Desarrollo** y tus capacidades personales al máximo. Puesto que son lo suficientemente grandes como para cubrir las tareas asignadas, permanecen en verde. Sin embargo, la capacidad global del **Equipo** se supera debido a las 3 horas adicionales que requiere la tarea **Optimizar datos de consulta para los últimos tutoriales vistos**.
 
@@ -279,11 +279,11 @@ El trabajo pendiente de sprint debe contener toda la información que el equipo 
 
 14. En la sección **Criterios de regla**, en la lista desplegable **Campo**, selecciona **Actividad**, en la lista desplegable **Operador**, selecciona **=** y, en la lista desplegable **Valor**, selecciona **Desarrollo.**
 
-    ![En la ventana "Configuración", asegúrate de que todos los campos tengan información.](images/m1/EShop-WEB-styles_v1.png)
+    ![En la ventana "Configuración", asegúrate de que todos los campos tengan información.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-styles_v1.png)
 
     > **Nota**: todas las tarjetas asignadas a actividades de **Desarrollo** aparecerán de color verde.
 
-    ![Estilos de tareas de sprint](images/m1/EShop-WEB-sprint-green_v1.png)
+    ![Estilos de tareas de sprint](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-sprint-green_v1.png)
 
 15. En el panel **Configuración**, selecciona la pestaña **Backlogs** (Trabajos pendientes).
 
@@ -314,7 +314,7 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 
 3. En el panel **Configuración**, selecciona la pestaña **Colores de etiqueta** y haz clic en **+ Color de etiqueta**. En el cuadro de texto ** Etiqueta**, escribe **datos** y deja el color predeterminado.
 
-    ![En la ventana "Configuración", "Colores de etiqueta", incluir la etiqueta "datos"](images/m1/EShop-WEB-tag_color_v1.png)
+    ![En la ventana "Configuración", "Colores de etiqueta", incluir la etiqueta "datos"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-tag_color_v1.png)
 
     > **Nota**: cada vez que se etiqueta un elemento de trabajo pendiente o un error con **datos**, esa etiqueta se resaltará.
 
@@ -333,7 +333,7 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 10. Repite el paso anterior para agregar la etiqueta **ux**.
 11. Guarde estas modificaciones haciendo clic en **Guardar y cerrar**.
 
-    ![En el panel "Como cliente, me gustaría ver nuevos tutoriales", haz clic en "Guardar y cerrar".](images/m1/EShop-WEB-tags_v1.png)
+    ![En el panel "Como cliente, me gustaría ver nuevos tutoriales", haz clic en "Guardar y cerrar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-tags_v1.png)
 
     > **Nota**: ahora las dos etiquetas están visibles en la tarjeta, con la etiqueta **datos** resaltada en amarillo.
 
@@ -346,7 +346,7 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 
     > **Nota**: el límite de trabajo en curso de 1 indica que solo puede haber un elemento de trabajo a la vez en esta fase. Normalmente, establecerías un valor más alto, pero solo hay dos elementos de trabajo para demostrar la característica.
 
-    ![En el panel "Configuración", haz clic en "Guardar y cerrar"](images/m1/EShop-WEB-qa_column_v1.png)
+    ![En el panel "Configuración", haz clic en "Guardar y cerrar"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-qa_column_v1.png)
 
 15. En el panel **Configuración**, seleccione de nuevo la pestaña **Columnas**. Fíjese en los puntos suspensivos junto a la columna **QA aprobado** que ha creado. Seleccione **Mover a la derecha** dos veces, para que la columna QA aprobado se sitúe entre **Confirmado** y **Hecho**.
 16. En el panel **Configuración**, haga clic en **Guardar**.
@@ -355,7 +355,7 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 18. Arrastra el elemento de trabajo **Como cliente, me gustaría ver los últimos tutoriales que he visto** desde la fase **Confirmado** hasta **Control de calidad aprobado**.
 19. Arrastra el elemento de trabajo **Como cliente, me gustaría ver nuevos tutoriales** desde la fase **Aprobado** hasta **Control de calidad aprobado**.
 
-    ![La fase supera ahora su límite **WIP** y aparece en rojo como una advertencia junto a la columna "Control de calidad aprobado"](images/m1/EShop-WEB-wip_limit_v1.png)
+    ![La fase supera ahora su límite **WIP** y aparece en rojo como una advertencia junto a la columna "Control de calidad aprobado"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-wip_limit_v1.png)
 
     > **Nota**: la fase ahora supera su límite **WIP** y aparece en rojo como advertencia.
 
@@ -372,11 +372,11 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 24. En la pestaña **Control de calidad aprobado**, en la parte inferior del panel, en el cuadro de texto **Definición de Listo**, escribe **Passa \*\*todas\*\* las pruebas**.
 25. En el panel **Configuración**, haz clic en **Guardar y cerrar**.
 
-    ![En el panel "Configuración", revisa la información y haz clic en "Guardar y cerrar".](images/m1/dd_v1.png)
+    ![En el panel "Configuración", revisa la información y haz clic en "Guardar y cerrar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/dd_v1.png)
 
     > **Nota**: la fase **Control de calidad aprobado** ahora tiene las columnas **En curso** y **Listo** . También puedes hacer clic en el símbolo informativo (con la letra **i** en un círculo) junto al encabezado de columna para leer la **Definición de Listo**.
 
-![División de columnas para QA aprobado](images/m1/EShop-WEB-qa_2columns_v1.png)
+![División de columnas para QA aprobado](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-qa_2columns_v1.png)
 
 26. En el panel **Boards**, haga clic en el icono de engranaje **Configurar ajustes del panel** (directamente a la derecha del icono del embudo).
 
@@ -386,7 +386,7 @@ Para maximizar la capacidad de un equipo de ofrecer software de alta calidad de 
 28. En la pestaña **Calles**, haz clic en **+ Calle** debajo de la etiqueta **Nombre de la calle**, en el cuadro de texto **Nombre**, escribe **Acelerar**.
 29. En el panel **Configuración**, haga clic en **Guardar**.
 
-    ![En el panel "Configuración", revise la información y haga clic en "Guardar".](images/m1/EShop-WEB-swimlane_v1.png)
+    ![En el panel "Configuración", revise la información y haga clic en "Guardar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-swimlane_v1.png)
 
 30. Cuando vuelvas a la pestaña **Panel** del tablero **Paneles**, arrastra y coloca el elemento de trabajo **Confirmado** en la fase **Control de calidad aprobado\|En curso** por la calle **Acelerar** para que se reconozca como prioritario cuando el ancho de banda de control de calidad esté disponible.
 
@@ -403,7 +403,7 @@ Todos los procesos se comparten dentro de la misma organización. Es decir, uno 
 3. En el menú vertical **Configuración de la organización**, en la sección **Paneles**, selecciona **Proceso**.
 4. En el panel **Todos los procesos**, a la derecha de la entrada **Scrum**, selecciona los puntos suspensivos (...) y, en el menú desplegable, selecciona **Crear proceso heredado**.
 
-    ![En la ventana "Configuración de la organización", en la opción "Proceso", busca el proceso "Scrum" y haz clic en los puntos suspensivos (...) y "Crear proceso heredado"](images/m1/EShop-WEB-inherited_v1.png)
+    ![En la ventana "Configuración de la organización", en la opción "Proceso", busca el proceso "Scrum" y haz clic en los puntos suspensivos (...) y "Crear proceso heredado"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-inherited_v1.png)
 
 5. En el panel **Crear proceso heredado de Scrum**, en el cuadro de texto **Nombre del proceso (obligatorio)**, escribe **Scrum personalizado** y haz clic en **Crear proceso**.
 6. Cuando vuelvas al panel **Todos los procesos**, haz clic en la entrada **Scrum personalizado**.
@@ -412,24 +412,24 @@ Todos los procesos se comparten dentro de la misma organización. Es decir, uno 
 
 7. En el panel **Todos los procesos > Scrum personalizado**, selecciona **Elemento de trabajo pendiente**.
 
-    ![En el panel "Todos los procesos > Scrum personalizado", selecciona "Elemento de trabajo pendiente"](images/m1/EShop-WEB-pbi_field_name_v1.png)
+    ![En el panel "Todos los procesos > Scrum personalizado", selecciona "Elemento de trabajo pendiente"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-pbi_field_name_v1.png)
 
 8. En el panel **Todos los procesos > Scrum personalizado > Elemento de trabajo pendiente**, haz clic en **Campo nuevo**.
 9. En el panel **Agregar un campo al elemento de trabajo pendiente**, en la pestaña **Definición**, en la sección **Crear un campo**, en el cuadro de texto **Nombre**, escribe **Identificador de vale de EShop**.
 
-    ![En el panel "Agregar un campo al elemento de trabajo pendiente", en la pestaña "Definición", en la sección "Crear un campo", en el cuadro de texto "Nombre", escribe "Identificador de vale de EShop".](images/m1/EShop-WEB-pbi_v1.png)
+    ![En el panel "Agregar un campo al elemento de trabajo pendiente", en la pestaña "Definición", en la sección "Crear un campo", en el cuadro de texto "Nombre", escribe "Identificador de vale de EShop".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-pbi_v1.png)
 
 10. En el panel **Agregar un campo al elemento de trabajo pendiente**, haz clic en **Diseño**.
 11. En el panel **Agregar un campo al elemento de trabajo pendiente**, en la pestaña **Diseño**, en el cuadro de texto **Etiqueta**, escribe **Identificador de vale**, selecciona la opción **Crear un nuevo grupo**, en el cuadro de texto **Grupo**, escribe **EShopOnWeb** y haz clic en **Agregar campo**.
 
-    ![En el panel "Agregar un campo al elemento de trabajo pendiente", en la pestaña "Diseño", asegúrate de que se ha incluido la información y haz clic en "Agregar campo".](images/m1/EShop-WEB-pbi_field_layout_v1.png)
+    ![En el panel "Agregar un campo al elemento de trabajo pendiente", en la pestaña "Diseño", asegúrate de que se ha incluido la información y haz clic en "Agregar campo".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-pbi_field_layout_v1.png)
 
     > **Nota**: ahora que se ha configurado el proceso personalizado, vamos a cambiar al proyecto eShopOnWeb para usarlo.
 
 12. Vuelve a la raíz de **Todos los procesos** mediante la ruta de navegación en la sección superior de **Todos los procesos > Scrum personalizado > Elemento de trabajo pendiente**.
 13. En el panel **Todos los procesos**, selecciona la entrada **Scrum**.
 
-    ![En el panel "Todos los procesos", selecciona la entrada "Scrum".](images/m1/scrum_v1.png)
+    ![En el panel "Todos los procesos", selecciona la entrada "Scrum".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/scrum_v1.png)
 
     > **Nota**: nuestro proyecto actual usa **Scrum**.
 
@@ -437,7 +437,7 @@ Todos los procesos se comparten dentro de la misma organización. Es decir, uno 
 15. En la lista de proyectos, en la fila que contiene la entrada **eShopOnWeb**, selecciona el símbolo de puntos suspensivos (...) y, a continuación, selecciona **Cambiar proceso**.
 16. En el panel **Cambiar el proceso del proyecto**, en la lista desplegable **Seleccionar un proceso de destino**, selecciona el proceso **Personalización de Scrum**, haz clic en **Guardar** y después en **Cerrar**.
 
-    ![En el panel "Cambiar el proceso del proyecto", en la lista desplegable "Seleccionar un proceso de destino", selecciona el proceso "Scrum personalizado", haz clic en "Guardar" y después en "Cerrar".](images/m1/EShop-WEB-custom_scrum_v1.png)
+    ![En el panel "Cambiar el proceso del proyecto", en la lista desplegable "Seleccionar un proceso de destino", selecciona el proceso "Scrum personalizado", haz clic en "Guardar" y después en "Cerrar".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-custom_scrum_v1.png)
 
 17. Haz clic en el logotipo de **Azure DevOps** en la esquina superior izquierda para volver a la página raíz de la cuenta.
 18. En la pestaña **Proyectos**, selecciona la entrada que representa el proyecto **eShopOnWeb**.
@@ -445,7 +445,7 @@ Todos los procesos se comparten dentro de la misma organización. Es decir, uno 
 20. En la lista de elementos de trabajo, haz clic en el primer elemento de trabajo pendiente.
 21. Comprueba si ahora tienes el campo **Identificador de vale** en el grupo **eShopOnWeb**, que se definió durante la personalización del proceso. Puedes tratar esto como cualquier otro campo de texto.
 
-    ![Comprueba si ahora tienes el campo "Identificador de vale" en el grupo "eShopOnWeb", que se definió durante la personalización del proceso. Puedes tratar esto como cualquier otro campo de texto.](images/m1/EShop-WEB-verify_v1.png)
+    ![Comprueba si ahora tienes el campo "Identificador de vale" en el grupo "eShopOnWeb", que se definió durante la personalización del proceso. Puedes tratar esto como cualquier otro campo de texto.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-verify_v1.png)
 
     > **Nota**: una vez guardado el elemento de trabajo, Azure DevOps también guardará la nueva información personalizada para que esté disponible para las consultas y el resto de Azure DevOps.
 
@@ -458,15 +458,15 @@ Los paneles permiten a los equipos visualizar el estado y supervisar el progreso
 1. En el panel de navegación vertical del portal de Azure DevOps, selecciona el icono **Información general** y, en la lista de elementos **Información general**, selecciona **Paneles**.
 2. Si es necesario, en el panel **Paneles**, en la esquina superior izquierda, en la sección **Equipo de eShopOnWeb**, selecciona **Equipo de eShopOnWeb - Información general** y revisa el panel existente.
 
-    ![Si es necesario, en "Paneles", en la esquina superior izquierda, en la sección "Equipo de eShopOnWeb", selecciona "Equipo de eShopOnWeb Team - Información general"](images/m1/EShop-WEB-dashboard_v1.png)
+    ![Si es necesario, en "Paneles", en la esquina superior izquierda, en la sección "Equipo de eShopOnWeb", selecciona "Equipo de eShopOnWeb Team - Información general"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-dashboard_v1.png)
 
 3. En **Paneles**, selecciona el menú desplegable situado junto al título **Equipo de eShopOnWeb - Información general** y selecciona **+ Nuevo panel**.
 
-    ![En "Paneles", en la esquina superior izquierda, en la sección "Equipo de eShopOnWeb", selecciona "+ Nuevo panel".](images/m1/new_dashboard_v1.png)
+    ![En "Paneles", en la esquina superior izquierda, en la sección "Equipo de eShopOnWeb", selecciona "+ Nuevo panel".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/new_dashboard_v1.png)
 
 4. En el panel **Crear un panel**, en el cuadro de texto **Nombre**, escribe **Entrenamiento del producto**, en la lista desplegable **Equipo**, selecciona el equipo **EShop-WEB** y haz clic en **Crear**.
 
-    ![En "Crear un panel", en el cuadro de texto "Nombre", escribe "Entrenamiento del producto", en la lista desplegable "Equipo", selecciona el equipo "EShop-WEB" y haz clic en "Crear".](images/m1/EShop-WEB-create_dash_v1.png)
+    ![En "Crear un panel", en el cuadro de texto "Nombre", escribe "Entrenamiento del producto", en la lista desplegable "Equipo", selecciona el equipo "EShop-WEB" y haz clic en "Crear".](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-create_dash_v1.png)
 
 5. En el panel de nuevo panel, haz clic en **Agregar un widget**.
 6. En el panel **Agregar widget**, en el cuadro de texto **Buscar**, escribe **sprint** para buscar widgets existentes que se centran en los sprints. En la lista de resultados, selecciona **Información general de sprint** y haz clic en **Agregar**.
@@ -478,7 +478,7 @@ Los paneles permiten a los equipos visualizar el estado y supervisar el progreso
 9. Cuando vuelvas al panel **Agregar widget**, en el cuadro de texto **Buscar**, escribe **sprint** nuevamente para buscar widgets existentes que se centren en sprints. En la lista de resultados, selecciona **Capacidad de sprint** y haz clic en **Agregar**.
 10. En la vista **Panel**, en la parte superior del panel, haz clic en **Edición finalizada**.
 
-    ![La revisión del panel finalizado debe tener ambos widgets](images/m1/EShop-WEB-finished_dashboard_v1.png)
+    ![La revisión del panel finalizado debe tener ambos widgets](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-finished_dashboard_v1.png)
 
     > **Nota**: ahora puedes revisar dos aspectos importantes del sprint actual en el panel personalizado.
 
@@ -490,13 +490,13 @@ Los paneles permiten a los equipos visualizar el estado y supervisar el progreso
 14. En la pestaña **Editor** del panel **Consultas > Mis consultas**, en la segunda fila, en la columna **Campo**, selecciona **Ruta de acceso del área** y, en la lista desplegable ** Valor** correspondiente, selecciona **eShopOnWeb\\EShop-WEB**.
 15. Haz clic en **Guardar consulta**.
 
-    ![En la pestaña "Editor" del panel "Consultas > Mis consultas", en la segunda fila, en la columna "Campo", selecciona "Ruta de acceso del área" y, en la lista desplegable "Valor" correspondiente, selecciona "eShopOnWeb\\EShop-WEB"](images/m1/EShop-WEB-query_v1.png)
+    ![En la pestaña "Editor" del panel "Consultas > Mis consultas", en la segunda fila, en la columna "Campo", selecciona "Ruta de acceso del área" y, en la lista desplegable "Valor" correspondiente, selecciona "eShopOnWeb\\EShop-WEB"](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-query_v1.png)
 
 16. En el panel **Nueva consulta**, en el cuadro de texto **Escribir nombre**, escribe **Tareas web**, en la lista desplegable **Carpeta**, selecciona **Consultas compartidas** y haz clic en **Aceptar**.
 17. En la vista **Consultas>Consultas compartidas**, seleccione la pestaña **Gráficos** y haga clic en **+ Nuevo gráfico**.
 18. En el panel **Configurar gráfico**, en el cuadro de texto **Nombre**, escriba **Tareas web - Por asignación**, en la lista desplegable **Agrupar por**, seleccione **Asignado a** y haga clic en **Guardar gráfico** para guardar los cambios.
 
-    ![En el panel "Configurar gráfico", en el cuadro de texto "Nombre", escribe "Tareas web: por asignación"; y en la lista desplegable "Agrupar por", selecciona "Asignada a" y haz clic en "Aceptar" para guardar los cambios.](images/m1/EShop-WEB-chart_v1.png)
+    ![En el panel "Configurar gráfico", en el cuadro de texto "Nombre", escribe "Tareas web: por asignación"; y en la lista desplegable "Agrupar por", selecciona "Asignada a" y haz clic en "Aceptar" para guardar los cambios.](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m1/EShop-WEB-chart_v1.png)
 
     > **Nota**: ahora puedes agregar este gráfico a un panel.
 

--- a/Instructions/Labs/AZ400_M02_L02_Version_Controlling_with_Git_in_Azure_Repos.md
+++ b/Instructions/Labs/AZ400_M02_L02_Version_Controlling_with_Git_in_Azure_Repos.md
@@ -53,7 +53,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y elige **Scrum** en la lista desplegable **Proceso del elemento de trabajo**. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -61,7 +61,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar**. En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** tiene canalizaciones de YAML de Azure DevOps.
@@ -106,7 +106,7 @@ En esta tarea, aprenderás a clonar un repositorio de Git con Visual Studio Code
 
 3. En la esquina superior derecha del panel del repositorio **eShopOnWeb**, haz clic en **Clonar**.
 
-    ![Clonación del repositorio de Git](images/clone-repo.png)
+    ![Clonación del repositorio de Git](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/clone-repo.png)
 
     > **Nota**: la obtención de una copia local de un repo de Git se denomina *clonación*. Cada herramienta de desarrollo estándar admite esto y podrá conectarse a Azure Repos para extraer las fuentes más recientes para trabajar.
 
@@ -122,7 +122,7 @@ En esta tarea, aprenderás a clonar un repositorio de Git con Visual Studio Code
 
 8. En el símbolo de la paleta de comandos, ejecuta el comando **Git: Clone**.
 
-    ![Paleta de comandos de VS Code](images/vscode-command.png)
+    ![Paleta de comandos de VS Code](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/vscode-command.png)
 
     > **Nota**: para ver todos los comandos pertinentes, puedes empezar escribiendo **Git**.
 
@@ -162,7 +162,7 @@ En esta tarea, usarás Visual Studio Code para confirmar los cambios.
 4. En la ventana de Visual Studio Code, selecciona la pestaña **CONTROL DE CÓDIGO FUENTE** para comprobar que Git ha reconocido el cambio más reciente en el archivo que reside en el clon local del repositorio de Git.
 5. Con la pestaña **CONTROL DE CÓDIGO FUENTE** seleccionada, en la parte superior del panel, en el cuadro de texto, escribe **Mi confirmación** como mensaje de confirmación y presiona **Ctrl+Entrar** para confirmarlo en el equipo local.
 
-    ![Primera confirmación](images/first-commit.png)
+    ![Primera confirmación](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/first-commit.png)
 
 6. Si debes almacenar de manera automática y provisional los cambios, y confirmarlos directamente, haz clic en **Siempre**.
 
@@ -178,7 +178,7 @@ En esta tarea, usarás el portal de Azure DevOps para revisar las confirmaciones
 2. En el panel de navegación vertical del portal de Azure DevOps, en la sección **Repos**, selecciona **Confirmaciones**.
 3. Comprueba que la confirmación aparezca en la parte superior de la lista.
 
-    ![Confirmaciones del repo de ADO](images/ado-commit.png)
+    ![Confirmaciones del repo de ADO](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/ado-commit.png)
 
 #### Tarea 3: cambiar fases
 
@@ -204,7 +204,7 @@ En esta tarea, descubrirás el uso de cambios de almacenamiento provisional medi
 
 6. Con la pestaña **CONTROL DE CÓDIGO FUENTE** seleccionada, en la parte superior del panel, en el cuadro de texto, escribe **Comentarios agregados** como mensaje de confirmación.
 
-    ![Cambios almacenados provisionalmente](images/staged-changes.png)
+    ![Cambios almacenados provisionalmente](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/staged-changes.png)
 
 7. En la parte superior de la pestaña **CONTROL DE CÓDIGO FUENTE**, haz clic en los puntos suspensivos. En el menú desplegable, selecciona **Confirmar** y, en el menú en cascada, selecciona **Confirmar elementos almacenados provisionalmente**.
 8. En la esquina inferior izquierda de la ventana de Visual Studio Code, haz clic en el botón **Sincronizar cambios** para sincronizar los cambios confirmados con el servidor y, si el sistema te pregunta si quieres continuar, haz clic en **Aceptar** para insertar y extraer confirmaciones hacia los elementos **origin/main** y desde ellos.
@@ -225,7 +225,7 @@ En esta tarea, conocerás el historial de confirmaciones mediante el portal de A
 
 1. Con la pestaña **CONTROL DE CÓDIGO FUENTE** de la ventana de Visual Studio Code abierta, selecciona **Constants.cs** que representa la versión no almacenada provisionalmente del archivo.
 
-    ![Comparación de archivos](images/file-comparison.png)
+    ![Comparación de archivos](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/file-comparison.png)
 
     > **Nota**: se abre una vista de comparación que te permite localizar fácilmente los cambios realizados. En este caso, es solo un comentario.
 
@@ -233,7 +233,7 @@ En esta tarea, conocerás el historial de confirmaciones mediante el portal de A
 3. Desplázate hacia abajo hasta la entrada **Mi confirmación** (insertada anteriormente) y mantén el puntero del mouse sobre esta hasta ver los puntos suspensivos a la derecha.
 4. Haz clic en los puntos suspensivos y, en el menú desplegable, selecciona **Examinar archivos** y revisa los resultados.
 
-    ![Exploración de la confirmación](images/commit-browse.png)
+    ![Exploración de la confirmación](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/commit-browse.png)
 
     > **Nota**: esta vista representa el estado del origen correspondiente a la confirmación, lo que te permite revisar y descargar los archivos de origen.
 
@@ -253,7 +253,7 @@ En esta tarea, crearás una rama mediante Visual Studio Code.
 2. Con la pestaña **CONTROL DE CÓDIGO FUENTE** seleccionada, en la esquina inferior izquierda de la ventana de Visual Studio Code, haz clic en **main**.
 3. En la ventana emergente, selecciona **+ Crear nueva rama desde...**.
 
-    ![Crear rama](images/create-branch.png)
+    ![Crear rama](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-branch.png)
 
 4. En el cuadro de texto **Nombre de rama**, escribe **dev** para especificar la nueva rama y presiona **Entrar**.
 5. En el cuadro de texto **Seleccionar una referencia para crear la rama "dev"**, selecciona **main** como la rama de referencia.
@@ -272,7 +272,7 @@ Git realiza un seguimiento de la rama en la que estás trabajando y se asegura d
 4. Mantén el puntero del mouse sobre la entrada de la rama **dev** para ver los puntos suspensivos a la derecha.
 5. Haz clic en los puntos suspensivos y, en el menú emergente, selecciona **Eliminar rama** y, cuando el sistema te pida confirmación, haz clic en **Eliminar**.
 
-    ![Eliminar rama](images/delete-branch.png)
+    ![Eliminar rama](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/delete-branch.png)
 
 6. Vuelve a la ventana de **Visual Studio Code** y, con la pestaña ** CONTROL DE CÓDIGO FUENTE** seleccionada, en la esquina inferior izquierda de la ventana de Visual Studio Code, haz clic en la entrada **dev**. Verás las ramas existentes en la parte superior de la ventana de Visual Studio Code.
 7. Comprueba que haya dos ramas **dev** en la lista.
@@ -306,7 +306,7 @@ En esta tarea, usarás el portal de Azure DevOps para restaurar la rama que has 
 5. En la sección **Ramas eliminadas**, mantén el puntero del mouse sobre la entrada de rama **dev** para ver los puntos suspensivos a la derecha.
 6. Haz clic en los puntos suspensivos y, en el menú emergente, selecciona **Restaurar rama**.
 
-    ![restaurar rama](images/restore-branch.png)
+    ![restaurar rama](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/restore-branch.png)
 
     > **Nota**: puedes usar esta funcionalidad para restaurar una rama eliminada si conoces su nombre exacto.
 
@@ -320,12 +320,12 @@ Para simplificar, trabajaremos directamente en el editor de repositorios del exp
 2. En la pestaña **Mías** del panel **Ramas**, mantén el puntero del mouse sobre la entrada de rama **main** para ver los puntos suspensivos a la derecha.
 3. Haz clic en los puntos suspensivos y, en el menú emergente, selecciona **Directivas de ramas**.
 
-    ![Directivas de ramas](images/branch-policies.png)
+    ![Directivas de ramas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/branch-policies.png)
 
 4. En la pestaña **main** de la configuración del repositorio, habilita la opción **Requerir un número mínimo de revisores**. Agrega **1** revisor y activa la casilla **Permitir que los solicitantes aprueben sus propios cambios** (ya que eres el único usuario del proyecto para el laboratorio)
 5. En la pestaña **main** de la configuración del repositorio, habilita la opción **Buscar elementos de trabajo vinculados** y déjala configurada como **Obligatorio**.
 
-    ![Configuración de directivas](images/policy-settings.png)
+    ![Configuración de directivas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/policy-settings.png)
 
 #### Tarea 5: prueba de la directiva de ramas
 
@@ -341,7 +341,7 @@ En esta tarea, usarás el portal de Azure DevOps para probar la directiva y crea
 
 4. Haz clic en **Confirmar > Confirmar**. Verás una advertencia: los cambios realizados en la rama principal solo se pueden hacer mediante una solicitud de incorporación de cambios.
 
-    ![Confirmación denegada de la directiva](images/policy-denied.png)
+    ![Confirmación denegada de la directiva](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/policy-denied.png)
 
 5. Haz clic en **Cancelar** para omitir la confirmación.
 
@@ -361,7 +361,7 @@ En esta tarea, usarás el portal de Azure DevOps para crear una solicitud de inc
 5. Haz clic en **Confirmar > Confirmar** (deja el mensaje de confirmación predeterminado). Esta vez la confirmación funciona, la rama **dev** no tiene directivas.
 6. Aparecerá un mensaje que propone crear una solicitud de incorporación de cambios (ya que la rama **dev** ahora tiene más cambios, en comparación con **main**). Haz clic en **Crear solicitud de incorporación de cambios**.
 
-    ![Crear una solicitud de cambios](images/create-pr.png)
+    ![Crear una solicitud de cambios](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-pr.png)
 
 7. En la pestaña **Nueva solicitud de incorporación de cambios**, deja los valores predeterminados y haz clic en **Crear**.
 8. La solicitud de incorporación de cambios mostrará algunos requisitos con errores o pendientes, en función de las directivas aplicadas a nuestra rama **main** de destino.
@@ -370,7 +370,7 @@ En esta tarea, usarás el portal de Azure DevOps para crear una solicitud de inc
 
 9. En las opciones del lado derecho, haz clic en el botón **+** situado junto a **Elementos de trabajo**. Haz clic en el elemento de trabajo creado anteriormente para vincularlo a la solicitud de incorporación de cambios. Verás uno de los cambios de estado de los requisitos.
 
-    ![Vincular elemento de trabajo](images/link-wit.png)
+    ![Vincular elemento de trabajo](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/link-wit.png)
 
 10. A continuación, abre la pestaña **Archivos** para revisar los cambios propuestos. En una solicitud de incorporación de cambios más completa, podrías revisar los archivos uno por uno (marcado como revisado) y abrir comentarios en las líneas que se pueden prestar a confusión (pasa el mouse sobre el número de línea y verás la opción de publicar un comentario).
 11. Vuelve a la pestaña **Información general** y, en la parte superior derecha, haz clic en **Aprobar**. Todos los requisitos se verán en verde. Ahora puedes hacer clic en **Completar**.
@@ -399,12 +399,12 @@ Al pasar por los diferentes laboratorios del curso en el orden en que se present
 2. En la pestaña **Mina** del panel **Ramas**, pase el puntero del ratón por encima de la entrada de la rama **principal** para que aparezca el símbolo de puntos suspensivos (...) a la derecha.
 3. Haz clic en los puntos suspensivos y, en el menú emergente, selecciona **Directivas de ramas**.
 
-    ![Configuración de directivas](images/policy-settings.png)
+    ![Configuración de directivas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/policy-settings.png)
 
 4. En la pestaña **principal** de la configuración del repositorio, desactive la opción para **Requerir un número mínimo de revisores**.
 5. En la pestaña **principal** de la configuración del repositorio, desactive la opción de **Comprobar elementos de trabajo vinculados**.
 
-    ![Directivas de ramas](images/branch-policies.png)
+    ![Directivas de ramas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/branch-policies.png)
 
 6. Ahora ha deshabilitado o quitado las directivas de rama de la rama principal.
     

--- a/Instructions/Labs/AZ400_M03_L03_Configuring_Agent_Pools_and_Understanding_Pipeline_Styles.md
+++ b/Instructions/Labs/AZ400_M03_L03_Configuring_Agent_Pools_and_Understanding_Pipeline_Styles.md
@@ -174,7 +174,7 @@ En esta tarea, configurarás la máquina virtual de laboratorio como agente de a
 
     > **ADVERTENCIA**: ten cuidado con copiar y pegar, asegúrate de que tienes la misma sangría que se mostraba anteriormente.
 
-    ![Sintaxis del grupo de YAML](images/m3/eshoponweb-ci-pr-pool_v1.png)
+    ![Sintaxis del grupo de YAML](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m3/eshoponweb-ci-pr-pool_v1.png)
 
 23. En la esquina superior derecha del panel de **EShopOnWeb**, haga clic en **Guardar y ejecutar**. Esto desencadenará automáticamente la compilación basada en esta canalización.
 24. En el portal de Azure DevOps, en el panel de navegación vertical del lado izquierdo, en la sección **Canalizaciones**, haz clic en **Canalizaciones**. En función de la configuración del laboratorio, es posible que la canalización le solicite permisos. Haga clic en **Permitir** para permitir que se ejecute la canalización. 
@@ -187,7 +187,7 @@ En esta tarea, configurarás la máquina virtual de laboratorio como agente de a
 3. Revoca el token PAT.
 4. Revierta los cambios en el archivo **eshoponweb-ci-pr.yml**; para ello, vaya a él desde Repos/.ado/eshoponweb-ci-pr.yml, seleccione **Editar** y quite las líneas 13 a 15 (el fragmento de código del grupo de agentes) y cámbielo a `vmImage: windows-latest`, tal como estaba inicialmente. (Esto se debe a que usará el mismo archivo de canalización de ejemplo más adelante en un ejercicio de laboratorio). 
 
-![Revertir el grupo de canalizaciones a la configuración de vmImage](images/m3/eshoponweb-ci-pr-vmimage_v1.png)
+![Revertir el grupo de canalizaciones a la configuración de vmImage](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m3/eshoponweb-ci-pr-vmimage_v1.png)
 
 ## Revisar
 

--- a/Instructions/Labs/AZ400_M03_L05_Implementing_GitHub_Actions_for_CI_CD.md
+++ b/Instructions/Labs/AZ400_M03_L05_Implementing_GitHub_Actions_for_CI_CD.md
@@ -50,7 +50,7 @@ En esta tarea, crearás un repositorio de GitHub público vacío e importarás e
 
 1. En el equipo del laboratorio, abre un explorador web, accede al [sitio web de GitHub](https://github.com/), inicia sesión con tu cuenta y haz clic en **Nuevo** para crear un repositorio nuevo.
 
-    ![Crear repositorio](images/github-new.png)
+    ![Crear repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/github-new.png)
 
 2. En la página **Crear un nuevo repositorio**, haz clic en el vínculo **Importar un repositorio** (debajo del título de página).
 
@@ -69,7 +69,7 @@ En esta tarea, crearás un repositorio de GitHub público vacío e importarás e
 
 5. En la página del repositorio, ve a **Configuración**, haz clic en **Acciones > General** y elige la opción **Permitir todas las acciones y los flujos de trabajo reutilizables**. Haga clic en **Guardar**.
 
-    ![Habilitación de Acciones de GitHub](images/enable-actions.png)
+    ![Habilitación de Acciones de GitHub](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/enable-actions.png)
 
 ### Ejercicio 1: configuración de tu repositorio de GitHub y el acceso a Azure
 
@@ -139,15 +139,15 @@ En esta tarea, revisarás la ejecución del flujo de trabajo de GitHub:
 1. En una ventana del explorador, vuelve al repositorio de GitHub **eShopOnWeb** .
 2. En la página del repositorio, ve a **Acciones** y verás la configuración del flujo de trabajo antes de ejecutarse. Haga clic en él.
 
-    ![Flujo de trabajo de GitHub en curso](images/gh-actions.png)
+    ![Flujo de trabajo de GitHub en curso](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/gh-actions.png)
 
 3. Espera a que finalice la ejecución del flujo de trabajo. En **Resumen**, puedes ver las dos tareas del flujo de trabajo, el estado y los artefactos retenidos de la ejecución. Puedes hacer clic en cada trabajo para revisar los registros.
 
-    ![Ejecución correcta del flujo de trabajo](images/gh-action-success.png)
+    ![Ejecución correcta del flujo de trabajo](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/gh-action-success.png)
 
 4. En otra ventana de navegador, vuelve al Portal de Azure https://portal.azure.com/). Abre el grupo de recursos creado antes. Verás que la Acción de GitHub, mediante una plantilla de bicep, ha creado un plan de App Service de Azure y App Service. Puedes ver el sitio web publicado abriendo App Service y haciendo clic en **Examinar**.
 
-    ![Examinar WebApp](images/browse-webapp.png)
+    ![Examinar WebApp](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/browse-webapp.png)
 
 #### (OPCIONAL) Tarea 4: agregar la aprobación manual previa a la implementación mediante entornos de GitHub
 
@@ -164,13 +164,13 @@ En esta tarea, usarás entornos de GitHub para solicitar la aprobación manual a
 5. En la pestaña **Configurar desarrollo**, activa la opción **Revisores necesarios** y tu cuenta de GitHub como revisor. Haz clic en **Guardar reglas de protección**.
 6. Ahora vamos a probar la regla de protección. En la página del repositorio, ve a **Acciones**, haz clic en el flujo de trabajo **Compilación y prueba de eShopOnWeb** y haz clic en **Ejecutar flujo de trabajo > Ejecutar flujo de trabajo** para la ejecución manual.
 
-    ![flujo de trabajo de desencadenador manual](images/gh-manual-run.png)
+    ![flujo de trabajo de desencadenador manual](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/gh-manual-run.png)
 
 7. Haz clic en la ejecución iniciada del flujo de trabajo y espera a que finalice el trabajo **compilación y prueba**. Verás una solicitud de revisión cuando llegues al trabajo **implementación**.
 
 8. Haz clic en **Revisar implementaciones**, marca **Desarrollo** y haz clic en **Aprobar e implementar**.
 
-    ![aprobación](images/gh-approve.png)
+    ![aprobación](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/gh-approve.png)
 
 9. El flujo de trabajo seguirá ejecutando el trabajo de **implementación** y finalizará.
 

--- a/Instructions/Labs/AZ400_M04_L07_Controlling_Deployments_using_Release_Gates.md
+++ b/Instructions/Labs/AZ400_M04_L07_Controlling_Deployments_using_Release_Gates.md
@@ -64,7 +64,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y deja los demás campos con los valores predeterminados. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ya la has completado) Importar repositorio de Git eShopOnWeb
 
@@ -72,7 +72,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar un repositorio**. Seleccione **Import** (Importar). En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.

--- a/Instructions/Labs/AZ400_M05_L08_Configuring_Pipelines_as_Code_with_YAML.md
+++ b/Instructions/Labs/AZ400_M05_L08_Configuring_Pipelines_as_Code_with_YAML.md
@@ -42,7 +42,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb_MultiStageYAML** Azure DevOp
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asigna al proyecto el nombre **eShopOnWeb_MultiStageYAML** y deja el resto de los campos con los valores predeterminados. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -50,7 +50,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo de laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto de **eShopOnWeb_MultiStageYAML creado **anteriormente. Haz clic en **Repos>Archivos**, **Importar un repositorio**. Seleccione **Import** (Importar). En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.

--- a/Instructions/Labs/AZ400_M05_L09_Setting_Up_and_Running_Tests.md
+++ b/Instructions/Labs/AZ400_M05_L09_Setting_Up_and_Running_Tests.md
@@ -125,13 +125,13 @@ Verás que la tarea Pruebas unitarias ya forma parte de la canalización.
 
 1. Una vez completada, la pestaña **Prueba** se mostrará como parte de la ejecución de la canalización. Hazle clic para ver el resumen. Deberías ver algo similar a esto:
 
-    ![Resumen de pruebas](images/AZ400_M05_L09_Tests_Summary.png)
+    ![Resumen de pruebas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/AZ400_M05_L09_Tests_Summary.png)
 
 1. Para más información, en la parte inferior de la página, la tabla muestra una lista de las distintas pruebas de ejecución.
 
     >**Nota**: si la tabla está vacía, debes restablecer los filtros para que se ejecuten todos los detalles sobre las pruebas.
 
-    ![Tabla de pruebas](images/AZ400_M05_L09_Tests_Table.png)
+    ![Tabla de pruebas](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/AZ400_M05_L09_Tests_Table.png)
 
 ## Revisar
 

--- a/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -48,7 +48,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y deja los demás campos con los valores predeterminados. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -56,7 +56,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar**. En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.
@@ -112,7 +112,7 @@ Azure Pipelines crea automáticamente una entidad de servicio cuando te conectas
 
 6. Después, desde el equipo del laboratorio, abre un explorador web y ve al proyecto **eShopOnWeb** de Azure DevOps. Haz clic en **Configuración del proyecto>Conexiones de servicio (en Canalizaciones)** y en **Nueva conexión de servicio**.
 
-    ![Nueva conexión de servicio](images/new-service-connection.png)
+    ![Nueva conexión de servicio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/new-service-connection.png)
 
     > **Nota**: Si no hay conexiones de servicio creadas anteriormente en la página, el botón de creación de la conexión de servicio se encuentra en el centro de la página y tiene la etiqueta **Crear conexión de servicio**
 
@@ -125,7 +125,7 @@ Azure Pipelines crea automáticamente una entidad de servicio cuando te conectas
     - Identificador de entidad de servicio (appId), clave de entidad de servicio (contraseña) e identificador de inquilino (inquilino).
     - En **Nombre de conexión de servicio**, escribe **azure subs**. Se hará referencia a este nombre en las canalizaciones de YAML cuando necesites una conexión de servicio de Azure DevOps para comunicarte con la suscripción de Azure.
 
-    ![Conexión del servicio de Azure](images/azure-service-connection.png)
+    ![Conexión del servicio de Azure](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/azure-service-connection.png)
 
 10. Haz clic en **Comprobar y guardar**.
 
@@ -139,7 +139,7 @@ En esta tarea, importarás una definición de canalización de CI YAML existente
 
 3. En la sección **Configurar**, selecciona **Archivo YAML de Azure Pipelines existente**. Proporciona la siguiente ruta de acceso **/.ado/eshoponweb-ci-dockercompose.yml** y haz clic en **Continuar**.
 
-    ![Selecciona Canalización](images/select-ci-container-compose.png)
+    ![Selecciona Canalización](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/select-ci-container-compose.png)
 
 4. En la definición de canalización de YAML, personaliza el nombre del grupo de recursos reemplazando **NAME** en **AZ400-EWebShop-NAME** y **YOUR-SUBSCRIPTION-ID** por tu propio identificador de suscripción de Azure.
 
@@ -154,11 +154,11 @@ En esta tarea, importarás una definición de canalización de CI YAML existente
 
 7. Una vez finalizada la ejecución, en Azure Portal, abre el grupo de recursos definido previamente y verás la instancia de Azure Container Registry (ACR) con las imágenes de contenedor creadas, **eshoppublicapi** y **eshopwebmvc**. Solo usarás **eshopwebmvc** en la fase de implementación.
 
-    ![Imágenes de contenedor en ACR](images/azure-container-registry.png)
+    ![Imágenes de contenedor en ACR](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/azure-container-registry.png)
 
 8. Haz clic en **Claves de acceso** y copia el valor de la **contraseña**. Se usará en la siguiente tarea, ya que lo mantendremos como secreto en el Almacén de claves de Azure.
 
-    ![Contraseña de ACR](images/acr-password.png)
+    ![Contraseña de ACR](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/acr-password.png)
 
 #### Tarea 2: crear una instancia del Almacén de claves de Azure
 
@@ -224,7 +224,7 @@ En esta tarea, creará un grupo de variables en Azure DevOps que recuperará el 
 4. En **Variables**, haz clic en **+ Agregar** y selecciona el secreto **acr-secret**. Haga clic en **Aceptar**.
 5. Haga clic en **Guardar**.
 
-    ![Creación de grupo de variables](images/vg-create.png)
+    ![Creación de grupo de variables](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/vg-create.png)
 
 #### Tarea 4: configurar la canalización de CD para implementar el contenedor en instancias de Azure Container (ACI)
 

--- a/Instructions/Labs/AZ400_M06_L12_Azure_Deployments_Using_Resource_Manager_Templates.md
+++ b/Instructions/Labs/AZ400_M06_L12_Azure_Deployments_Using_Resource_Manager_Templates.md
@@ -45,7 +45,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y deja los demás campos con los valores predeterminados. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -53,7 +53,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar un repositorio**. Seleccione **Import** (Importar). En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 1. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.
@@ -72,7 +72,7 @@ En esta tarea, usará Visual Studio Code para crear una plantilla de Azure Bicep
 
 1. En la pestaña del explorador que tiene abierto el proyecto de Azure DevOps, ve a **Repos** y **Archivos**. Abre la carpeta `.azure\bicep` y busca el archivo `simple-windows-vm.bicep`.
 
-   ![Archivo simple-windows-vm.bicep](./images/m06/browsebicepfile.png)
+   ![Archivo simple-windows-vm.bicep](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/browsebicepfile.png)
 
 1. Revisa la plantilla para comprender mejor su estructura. Hay algunos parámetros con tipos, valores predeterminados y validación, algunas variables y bastantes recursos con estos tipos:
 
@@ -90,7 +90,7 @@ En esta tarea, crearás un módulo de plantilla de almacenamiento **storage.bice
 
 1. En primer lugar, es necesario quitar el recurso de almacenamiento de nuestra plantilla principal. En la esquina superior derecha de la ventana del explorador, haz clic en el botón **Editar**:
 
-   ![Botón Editar](./images/m06/edit.png)
+   ![Botón Editar](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/edit.png)
 
 1. Ahora elimina el recurso de almacenamiento:
 
@@ -107,11 +107,11 @@ En esta tarea, crearás un módulo de plantilla de almacenamiento **storage.bice
 
 1. Sin embargo, confirma el archivo. Aún no hemos terminado con él.
 
-   ![Confirmación del archivo](./images/m06/commit.png)
+   ![Confirmación del archivo](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/commit.png)
 
 1. Luego, mantén el ratón sobre la carpeta bicep, haz clic en el icono de puntos suspensivos y luego selecciona **Nuevo** y **Archivo**. Escribe **storage.bicep** para el nombre y haz clic en **Crear**.
 
-   ![Menú Nuevo archivo](./images/m06/newfile.png)
+   ![Menú Nuevo archivo](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/newfile.png)
 
 1. Ahora copia el siguiente fragmento de código en el archivo y confirma los cambios:
 
@@ -217,7 +217,7 @@ Azure Pipelines crea automáticamente una entidad de servicio cuando te conectas
 
 1. Después, desde el equipo del laboratorio, abre un explorador web y ve al proyecto **eShopOnWeb** de Azure DevOps. Haz clic en **Configuración del proyecto>Conexiones de servicio (en Canalizaciones)** y en **Nueva conexión de servicio**.
 
-    ![Nueva conexión de servicio](images/new-service-connection.png)
+    ![Nueva conexión de servicio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/new-service-connection.png)
 
 1. En la hoja **Nueva conexión de servicio**, selecciona **Administrador de recursos de Azure** y luego **Siguiente** (quizá debas desplazarte hacia abajo).
 
@@ -228,7 +228,7 @@ Azure Pipelines crea automáticamente una entidad de servicio cuando te conectas
     - Identificador de entidad de servicio (appId), clave de entidad de servicio (contraseña) e identificador de inquilino (inquilino).
     - En **Nombre de conexión de servicio**, escribe **azure subs**. Se hará referencia a este nombre en las canalizaciones de YAML cuando necesites una conexión de servicio de Azure DevOps para comunicarte con la suscripción de Azure.
 
-    ![Conexión del servicio de Azure](images/azure-service-connection.png)
+    ![Conexión del servicio de Azure](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/azure-service-connection.png)
 
 1. Haz clic en **Comprobar y guardar**.
 
@@ -248,10 +248,10 @@ Azure Pipelines crea automáticamente una entidad de servicio cuando te conectas
 1. En la sección variables, elige un nombre para el grupo de recursos, establece la ubicación que quieres y reemplaza el valor de la conexión de servicio por una de las conexiones de servicio existentes que has creado anteriormente.
 1. Haz clic en el botón **Guardar y ejecutar** de la esquina superior derecha y, cuando aparezca el cuadro de diálogo de confirmación, haz clic en **Guardar y ejecutar** de nuevo.
 
-   ![Guardar y ejecutar la canalización de YAML después de realizar cambios](./images/m06/saveandrun.png)
+   ![Guardar y ejecutar la canalización de YAML después de realizar cambios](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/saveandrun.png)
 
 1. Espera a que la implementación finalice y revisa los resultados.
-   ![Implementación correcta de recursos en Azure mediante canalizaciones de YAML](./images/m06/deploy.png)
+   ![Implementación correcta de recursos en Azure mediante canalizaciones de YAML](./https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m06/deploy.png)
 
 #### Tarea 3: Eliminar los recursos del laboratorio de Azure
 

--- a/Instructions/Labs/AZ400_M07_L13_Implement_Security_and_Compliance_in_an_Azure_Pipeline.md
+++ b/Instructions/Labs/AZ400_M07_L13_Implement_Security_and_Compliance_in_an_Azure_Pipeline.md
@@ -50,7 +50,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y deja los demás campos con los valores predeterminados. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -58,7 +58,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar**. En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.
@@ -77,7 +77,7 @@ En esta tarea, activarás WhiteSource Bolt en el proyecto de Azure Devops recié
 
 1. En el equipo de laboratorio, en la ventana del explorador web que muestra el portal de Azure DevOps con el proyecto **eShopOnWeb** abierto, haz clic en el icono de Marketplace > **Examinar Marketplace**.
 
-    ![Examinar Marketplace](images/browse-marketplace.png)
+    ![Examinar Marketplace](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/browse-marketplace.png)
 
 2. En Marketplace, busca **Mend Bolt (anteriormente WhiteSource)** y ábrelo. Mend Bolt es la versión gratuita de la herramienta WhiteSource conocida anteriormente, que examina todos los proyectos y detecta componentes de código abierto, su licencia y vulnerabilidades conocidas.
 
@@ -85,13 +85,13 @@ En esta tarea, activarás WhiteSource Bolt en el proyecto de Azure Devops recié
 
 3. En la página **Mend Bolt (anteriormente WhiteSource),** haz clic en **Obtenerlo de forma gratuita**.
 
-    ![Obtener Mend Bolt](images/mend-bolt.png)
+    ![Obtener Mend Bolt](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/mend-bolt.png)
 
 4. En la página siguiente, selecciona la organización de Azure DevOps correspondiente e **Instalar**. **Continúe con la organización** cuando haya finalizado la instalación.
 
 5. En Azure DevOps, ve a **Configuración de la organización** y selecciona **Mend** en **Extensiones**. Proporciona tu correo electrónico profesional (**tu cuenta personal del laboratorio**, por ejemplo, con AZ400learner@outlook.com en lugar de student@microsoft.com), el nombre de la empresa y otros detalles, y haz clic en el botón **Crear cuenta** para empezar a usar la versión gratuita.
 
-    ![Obtener cuenta Mend](images/mend-account.png)
+    ![Obtener cuenta Mend](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/mend-account.png)
 
 #### Tarea 2: crear y desencadenar una compilación
 
@@ -103,7 +103,7 @@ En esta tarea, crearás y desencadenarás una canalización de compilación de C
 
 3. En la sección **Configurar**, selecciona **Archivo YAML de Azure Pipelines existente**. Proporciona la siguiente ruta de acceso **/.ado/eshoponweb-ci-mend.yml** y haz clic en **Continuar**.
 
-    ![Selecciona Canalización](images/select-pipeline.png)
+    ![Selecciona Canalización](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/select-pipeline.png)
 
 4. Revisa la canalización y haz clic en **Ejecutar**. Tardará unos minutos en ejecutarse correctamente.
     > **Nota**: la compilación tardará algunos minutos en completarse. La canalización de compilación está formada por las siguientes tareas:
@@ -113,13 +113,13 @@ En esta tarea, crearás y desencadenarás una canalización de compilación de C
 
 5. Mientras se ejecuta la canalización, vamos a **cambiarle el nombre** para identificarlo más fácilmente (ya que el proyecto se puede usar para varios laboratorios). Ve a la sección **Canalizaciones/Canalizaciones** del proyecto de Azure DevOps, haz clic en el nombre de la canalización en ejecución (obtendrás un nombre predeterminado) y busca la opción **Cambiar nombre/mover** en el icono de puntos suspensivos. Cambia el nombre a **eshoponweb-ci-mend** y haz clic en **Guardar**.
 
-    ![Cambiar el nombre de la canalización](images/rename-pipeline.png)
+    ![Cambiar el nombre de la canalización](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/rename-pipeline.png)
 
 6. Una vez finalizada la ejecución de la canalización, puedes revisar los resultados. Abre la ejecución más reciente de la canalización **eshoponweb-ci-mend**. La pestaña de resumen mostrará los registros de la ejecución, junto con detalles relacionados, como la versión (confirmación) del repositorio usada, el tipo de desencadenador, los artefactos publicados, la cobertura de pruebas, etc.
 
 7. En la pestaña **Mend Bolt**, puedes revisar el análisis de seguridad de OSS. Verás detalles sobre el inventario usado, las vulnerabilidades encontradas (y cómo resolverlas) y un informe interesante sobre las licencias relacionadas con la biblioteca. Tómate un tiempo para revisar el informe.
 
-    ![Resultados de Mend](images/mend-results.png)
+    ![Resultados de Mend](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/mend-results.png)
 
 ## Revisar
 

--- a/Instructions/Labs/AZ400_M07_L14_Managing_technical_debt_with_SonarQube_and_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M07_L14_Managing_technical_debt_with_SonarQube_and_Azure_DevOps.md
@@ -52,7 +52,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y elige **Scrum** en la lista desplegable **Proceso del elemento de trabajo**. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -60,7 +60,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar**. En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** contiene canalizaciones de YAML de Azure DevOps.
@@ -77,7 +77,7 @@ En esta tarea, cambiarás la visibilidad del proyecto de Azure DevOps a público
 
 1. En el equipo de laboratorio, en la ventana del explorador web que muestra el portal de Azure DevOps, abre el proyecto **eShopOnWeb** y haz clic en **Configuración del proyecto** (esquina inferior izquierda). Cambia la **Visibilidad** a **Público**. Haga clic en **Guardar**
 
-![Proyecto de ADO con visualización pública](images/ado-public.png)
+![Proyecto de ADO con visualización pública](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/ado-public.png)
 
 #### Tarea 2: generar un token de acceso personal de Azure DevOps
 
@@ -85,7 +85,7 @@ En esta tarea, generarás un token de acceso personal de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en la ventana del explorador web que muestra el portal de Azure DevOps, en la esquina superior derecha de la página de Azure DevOps, haz clic en el icono **Configuración de usuario**; en el menú desplegable, haz clic en **Tokens de acceso personal** y en el panel **Tokens de acceso personal**, haz clic en **+ Nuevo token**.
 
-    ![Crear PAT](images/PAT.png)
+    ![Crear PAT](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/PAT.png)
 
 2. En el panel **Crear un nuevo token de acceso personal**, haz clic en el vínculo **Mostrar todos los ámbitos**, especifica la siguiente configuración y haz clic en **Crear** (deja las demás opciones con sus valores predeterminados):
 
@@ -122,7 +122,7 @@ En esta tarea, instalarás y configurarás la extensión SonarCloud Azure DevOps
 
 7. Haz clic en **Importar una organización desde Azure**.
 
-    ![Importar una organización de ADO a Sonarcloud](images/sonarcloud-import.png)
+    ![Importar una organización de ADO a Sonarcloud](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonarcloud-import.png)
 
 8. En la página **Crear una organización**, en el **nombre de la organización de Azure DevOps**, escribe el nombre de la organización de Azure DevOps. En el cuadro de texto **Token de acceso personal**, pega el valor del token de Azure DevOps que se ha registrado en la tarea anterior y haz clic en **Continuar**. **Sonarcloud usará este token para analizar el código hospedado en Azure DevOps**
 
@@ -139,13 +139,13 @@ En esta tarea, instalarás y configurarás la extensión SonarCloud Azure DevOps
 11. En la página **Analizar proyectos: seleccionar repositorios**, en la lista de proyectos de Azure DevOps, active la casilla situada junto a la entrada **eshoponweb / eshoponweb** y haga clic en **Configurar**.
 12. En la página **Elegir el método de análisis**, haz clic en el mosaico **Con canalizaciones de Azure DevOps**.
 
-    ![Con canalizaciones de Azure DevOps ](images/sonar-setup.png)
+    ![Con canalizaciones de Azure DevOps ](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-setup.png)
 
     > **Nota**: puedes omitir la creación de extensiones si ya la has instalado.
 
 13. En la página **Analizar un proyecto con Azure Pipelines**, en la página **Agregar un nuevo punto de conexión de servicio Sonarcloud**, sigue los pasos mencionados **en el proyecto de Azure DevOps**, asigna el nombre **SonarSC** a la conexión de servicio, **activa** la casilla para conceder acceso a todas las canalizaciones y haz clic en **Comprobar y guardar**.
 
-    ![Conexión de servicio Sonarcloud](images/sonar-sc.png)
+    ![Conexión de servicio Sonarcloud](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-sc.png)
 
     > **Nota**: en este paso se define cómo se comunicará la canalización de Azure con Sonarcloud. Sonarcloud proporciona un token que usan las canalizaciones para comunicarse con el servicio.
 
@@ -159,13 +159,13 @@ En esta tarea, instalarás y configurarás la extensión SonarCloud Azure DevOps
 
 18. Una vez modificada la canalización, haz clic en **Ejecutar**.
 
-    ![Canalización de Sonar CI](images/sonar-pipeline.png)
+    ![Canalización de Sonar CI](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-pipeline.png)
 
 19. Es posible que debas cambiar la **visibilidad** del proyecto de Azure DevOps a **Privado** para que los agentes ejecuten la canalización (Configuración del proyecto > Información general).
 
 20. En Azure DevOps, ve a  **Canalizaciones > Canalizaciones** y haz clic en la canalización creada recientemente, y cambia su nombre a **eshoponweb-sonar-ci**.
 
-    ![Cambiar el nombre de la canalización](images/sonar-rename.png)
+    ![Cambiar el nombre de la canalización](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-rename.png)
 
 #### Tarea 3: comprobar los resultados de la canalización
 
@@ -185,14 +185,14 @@ En esta tarea, comprobarás los resultados de la canalización.
 
 4. Haz clic en **Establecer nueva definición de código** y selecciona **Versión anterior**.
 
-    ![Informe de Sonarcloud](images/sonar-qg.png)
+    ![Informe de Sonarcloud](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-qg.png)
 
 5. Ve al explorador web en el **portal de Azure DevOps** con la ejecución de compilación más reciente. Haz clic en **Ejecutar nuevo** y, en el panel **Ejecutar canalización**, haz clic en **Ejecutar**.
 6. En el panel de ejecución de compilación, revisa el contenido de la pestaña **Resumen** y después haz clic en el encabezado de pestaña **Extensiones**.
 7. En la pestaña **Extensiones**, haz clic en el **informe SonarCloud detallado**. Se abrirá automáticamente una nueva pestaña del explorador que muestre el informe en la página del proyecto SonarCloud.
 8. Comprueba que el informe y la pestaña de **extensión** de Azure DevOps ahora **incluyan el resultado las validaciones de calidad**.
 
-    ![Validación de calidad aprobada](images/qg-passed.png)
+    ![Validación de calidad aprobada](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/qg-passed.png)
 
 ### Ejercicio 2: análisis de informes de SonarCloud
 
@@ -204,7 +204,7 @@ En esta tarea, analizarás los informes de SonarCloud.
 
 1. En la pestaña **Información general** del proyecto SonarCloud, vemos un resumen del informe sobre la ** evolución de la rama principal**. Si haces clic en el icono de **rama principal** (columna izquierda) y eliges **Código general**, verás un informe más detallado.
 
-    ![Informe de Sonarcloud](images/sonar-report.png)
+    ![Informe de Sonarcloud](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-report.png)
 
     > **Nota**: la página tiene métricas como **Código en mal estado**, **Cobertura**, **Duplicaciones** y **Tamaño** (líneas de código). En la tabla siguiente se explican estos términos.
 
@@ -243,7 +243,7 @@ En esta tarea, configurarás la integración de solicitudes de incorporación de
 4. En la sección **General** de la configuración de **solicitudes de incorporación de cambios**, en la lista desplegable **Proveedor**, selecciona **Azure DevOps Services** y haz clic en **Guardar**.
 5. En la sección **Integración con Azure DevOps Services** de la configuración de **solicitudes de incorporación de cambios**, en el cuadro de texto **Token de acceso personal**, pega el token de acceso personal de Azure DevOps generado anteriormente y haz clic en **Guardar**.
 
-    ![Configuración de la solicitud de incorporación de cambios de Sonarcloud](images/sonar-pr-setup.png)
+    ![Configuración de la solicitud de incorporación de cambios de Sonarcloud](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-pr-setup.png)
 
 #### Tarea 2: configurar una directiva de rama para la integración con SonarCloud
 
@@ -276,14 +276,14 @@ En esta tarea, validarás la integración de solicitudes de incorporación de ca
 4. En el panel **Program.cs**, haz clic en **Confirmar**.
 5. En el panel **Confirmar**, en el cuadro de texto **Nombre de rama**, escribe **branch1**, selecciona la casilla **Crear una solicitud de incorporación de cambios** y haz clic en **Confirmar**.
 
-    ![Confirmación de la solicitud de incorporación de cambios](images/sonar-pr-commit.png)
+    ![Confirmación de la solicitud de incorporación de cambios](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-pr-commit.png)
 
 6. En el panel **Nueva solicitud de incorporación de cambios**, selecciona **Crear**.
 7. En la pestaña **Información general** del panel **Program.cs** actualizado, supervisa el progreso de la compilación hasta su finalización.
 8. La canalización se realizará correctamente, pero se producirá un error en la comprobación opcional 1.
 9. Sonarcloud también agregará comentarios sobre las prácticas no recomendadas recientes a tu solicitud de incorporación de cambios. También puedes revisar el informe completo en Sonarcloud para obtener más información.
 
-    ![Error en la validación de calidad de la solicitud de incorporación de cambios](images/pr-qg-failed.png)![Sonarcloud Decorator](images/sonar-decorator.png)
+    ![Error en la validación de calidad de la solicitud de incorporación de cambios](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/pr-qg-failed.png)![Sonarcloud Decorator](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/sonar-decorator.png)
 
 #### Tarea 4: bloquear las solicitudes de incorporación de cambios en respuesta a errores en las comprobaciones de calidad del código
 

--- a/Instructions/Labs/AZ400_M09_L16_Monitoring_Application_Performance_with_Application_Insights.md
+++ b/Instructions/Labs/AZ400_M09_L16_Monitoring_Application_Performance_with_Application_Insights.md
@@ -50,7 +50,7 @@ En esta tarea, crearás un proyecto de **eShopOnWeb** de Azure DevOps que se usa
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps. Haz clic en **Nuevo proyecto**. Asígnale al proyecto el nombre **eShopOnWeb** y elige **Scrum** en la lista desplegable **Proceso del elemento de trabajo**. Haga clic en **Crear**.
 
-    ![Crear proyecto](images/create-project.png)
+    ![Crear proyecto](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/create-project.png)
 
 #### Tarea 2: (omitir si ha terminado) Importar repositorio de Git eShopOnWeb
 
@@ -58,7 +58,7 @@ En esta tarea, importarás el repositorio de Git eShopOnWeb que se usará en var
 
 1. En el equipo del laboratorio, en una ventana del explorador, abre la organización de Azure DevOps y el proyecto **eShopOnWeb** creado anteriormente. Haz clic en **Repos>Archivos**, **Importar**. En la ventana **Importar un repositorio de Git**, pega la siguiente dirección URL https://github.com/MicrosoftLearning/eShopOnWeb.git y haz clic en **Importar**:
 
-    ![Importar repositorio](images/import-repo.png)
+    ![Importar repositorio](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/import-repo.png)
 
 2. El repositorio se organiza de la siguiente manera:
     - La carpeta **.ado** tiene canalizaciones de YAML de Azure DevOps.
@@ -217,7 +217,7 @@ stages:
 
 Nota: si ha guardado todas las canalizaciones de los ejercicios de laboratorio anteriores, es posible que esta nueva canalización haya reutilizado el nombre de secuencia predeterminado **EShopOnWeb (#)** para la canalización, como se muestra en la captura de pantalla siguiente. Seleccione una canalización (si es posible, la que tenga el número de secuencia más alto, seleccione Editar y valide que apunta al archivo de código m09l16-pipeline.yml). 
 
-![](images/m3/eshoponweb-m9l16-pipeline.png)
+![](https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/images/m3/eshoponweb-m9l16-pipeline.png)
 
 11. Para confirmar que esta canalización se ejecuta, haga clic en **Ejecutar** en el panel que aparece y haga clic una vez más en **Ejecutar** para confirmar la operación.
 12. Verás que aparecen dos fases diferentes: **Compilar una solución .Net Core** e **Implementar en una aplicación web de Azure**.


### PR DESCRIPTION
This pull request includes changes to the image source URLs in the markdown files for Azure DevOps project instructions. The changes update the local image references to absolute URLs, pointing to the MicrosoftLearning GitHub repository.